### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -3,6 +3,9 @@ name: Docker cleanup
 on:
   workflow_dispatch:
 
+permissions:
+  packages: write
+
 jobs:
   delete_versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jamesmoore/novus-mail/security/code-scanning/29](https://github.com/jamesmoore/novus-mail/security/code-scanning/29)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow uses the `actions/delete-package-versions@v5` action to delete package versions, it requires `packages: write` permission. We will set this permission explicitly while keeping all other permissions at their minimal level (`read` or none). The `permissions` block will be added at the workflow level to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
