### PR TITLE
fix vite8 react-use-websocket reference

### DIFF
--- a/front-react/src/ws/websocket-notification-provider.tsx
+++ b/front-react/src/ws/websocket-notification-provider.tsx
@@ -1,9 +1,10 @@
 import { FC, ReactNode } from 'react';
-import useWebSocket from 'react-use-websocket';
+import { useWebSocket } from "react-use-websocket/dist/lib/use-websocket";
 import { WebSocketMessage, WebSocketContext } from './use-websocket-notifier';
 
 export const WebSocketNotificationProvider: FC<{ children: ReactNode; }> = ({ children }) => {
-    const webSocketHook = useWebSocket<WebSocketMessage>((import.meta.env.VITE_API_BASE_URL ?? '') + '/ws', {
+    const websocketUrl = `${import.meta.env.VITE_API_BASE_URL ?? ''}/ws`;
+    const webSocketHook = useWebSocket<WebSocketMessage>(websocketUrl, {
         onOpen: () => console.debug("ws connected"),
         shouldReconnect: () => true
     });

--- a/front-react/src/ws/websocket-notification-provider.tsx
+++ b/front-react/src/ws/websocket-notification-provider.tsx
@@ -3,8 +3,8 @@ import { useWebSocket } from "react-use-websocket/dist/lib/use-websocket";
 import { WebSocketMessage, WebSocketContext } from './use-websocket-notifier';
 
 export const WebSocketNotificationProvider: FC<{ children: ReactNode; }> = ({ children }) => {
-    const websocketUrl = `${import.meta.env.VITE_API_BASE_URL ?? ''}/ws`;
-    const webSocketHook = useWebSocket<WebSocketMessage>(websocketUrl, {
+    const webSocketUrl = `${import.meta.env.VITE_API_BASE_URL ?? ''}/ws`;
+    const webSocketHook = useWebSocket<WebSocketMessage>(webSocketUrl, {
         onOpen: () => console.debug("ws connected"),
         shouldReconnect: () => true
     });


### PR DESCRIPTION
This pull request makes a small change to the import statement for the `useWebSocket` hook in `websocket-notification-provider.tsx`, switching to a direct import from the internal library path. This can help resolve issues with tree-shaking or module resolution in some build setups.